### PR TITLE
하드코딩된 news_settings 수정

### DIFF
--- a/app/model/article_model.py
+++ b/app/model/article_model.py
@@ -4,28 +4,3 @@ from pydantic import BaseModel
 class ArticleResponse(BaseModel):
     title: str
     content: str
-
-# 뉴스 유형별 HTML 구조 설정
-news_settings = {
-    "MAE_KYUNG": {
-        "title_tag": "h2",
-        "title_class": "news_ttl",
-        "content_div_class": "news_cnt_detail_wrap",
-        "content_tags": ["p"],
-        "content_attrs": {"refid": True}
-    },
-    "HAN_KYUNG": {
-        "title_tag": "h1",
-        "title_class": "headline",
-        "content_div_class": "article-body",
-        "content_tags": ["p", "br"],
-        "content_attrs": {}
-    },
-    "SEOUL_KUNG": {
-        "title_tag": "div",
-        "title_class": "headline",
-        "content_div_class": "article",
-        "content_tags": ["p", "br"],
-        "content_attrs": {}
-    }
-}

--- a/app/model/article_publisher.py
+++ b/app/model/article_publisher.py
@@ -1,27 +1,49 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Dict, List, Optional
 
 from fastapi import HTTPException
 
 
 @dataclass
 class PublisherInfo:
-    name: str
-    crawled_class: Optional[str] = field(default=None)  # 크롤링 클래스
+    kr_name: Optional[str] = field(default=None)
+    title_tag: Optional[str] = field(default=None)
+    title_class: Optional[str] = field(default=None)
+    content_div_class: Optional[str] = field(default=None)
+    content_tags: Optional[List[str]] = field(default=None)
+    content_attrs: Optional[Dict[str, bool]] = field(default=None)
 
 
 class Publisher(Enum):
-    HAN_KYUNG = "한국경제"
-    MAE_KYUNG = "매일경제"
-    SEOUL_KUNG = "서울경제"
-
-    def __init__(self, name: str):
-        self._info = PublisherInfo(name=name, crawled_class="")
+    HAN_KYUNG = PublisherInfo(
+        kr_name="한국경제",
+        title_tag="h1",
+        title_class="headline",
+        content_div_class="article-body",
+        content_tags=["p", "br"],
+        content_attrs={},
+    )
+    MAE_KYUNG = PublisherInfo(
+        kr_name="매일경제",
+        title_tag="h2",
+        title_class="news_ttl",
+        content_div_class="news_cnt_detail_wrap",
+        content_tags=["p"],
+        content_attrs={"refid": True},
+    )
+    SEOUL_KYUNG = PublisherInfo(
+        kr_name="서울경제",
+        title_tag="div",
+        title_class="headline",
+        content_div_class="article",
+        content_tags=["p", "br"],
+        content_attrs={},
+    )
 
     @property
     def info(self) -> PublisherInfo:
-        return self._info
+        return self.value
 
 
 def find_publisher(name: str) -> Publisher:

--- a/app/router/news_scrap_router.py
+++ b/app/router/news_scrap_router.py
@@ -1,11 +1,26 @@
 from fastapi import APIRouter
+from groq import BaseModel
 
 from app.model.article_model import ArticleResponse
 from app.service.crawl_article_service import extract_article
+from app.utils.generic_response import GenericResponseDTO
 
 news_scrap_rotuer = APIRouter()
 
 
-@news_scrap_rotuer.get("/extract-article/{news_type}", response_model=ArticleResponse)
-async def extract_article_api(news_type: str, url: str):
-    return await extract_article(news_type, url)
+class ArticleCreateRequestDTO(BaseModel):
+    url: str
+    publisher: str
+
+
+@news_scrap_rotuer.post(
+    "/extract-article/{news_type}", response_model=GenericResponseDTO[ArticleResponse]
+)
+async def extract_article_api(articleCreateRequestDTO: ArticleCreateRequestDTO):
+    article = await extract_article(
+        news_type=articleCreateRequestDTO.publisher, url=articleCreateRequestDTO.url
+    )
+
+    return GenericResponseDTO(
+        data=article, message="Article extracted successfully", result=True
+    )

--- a/app/service/crawl_article_service.py
+++ b/app/service/crawl_article_service.py
@@ -1,57 +1,55 @@
-from fastapi import HTTPException
+import ssl
+
 import aiohttp
+from aiohttp import ClientSession
 from bs4 import BeautifulSoup
-from app.model.article_model import ArticleResponse, news_settings
+from fastapi import HTTPException
+
+from app.model.article_model import ArticleResponse
+from app.model.article_publisher import Publisher, find_publisher
+
 
 async def fetch_page(url: str) -> str:
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url) as response:
-            if response.status != 200:
-                raise HTTPException(status_code=400, detail=f"Error fetching the URL: {response.status}")
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+
+    async with ClientSession() as session:
+        async with session.get(url, ssl=ssl_context) as response:
             return await response.text()
 
-async def extract_article(news_type: str, url: str) -> ArticleResponse:
-    if news_type not in news_settings:
-        raise HTTPException(status_code=400, detail=f"Invalid news type: {news_type}")
 
-    settings = news_settings[news_type]
+async def extract_article(news_type: str, url: str) -> ArticleResponse:
+    news_type = find_publisher(news_type)
 
     # 웹 페이지 가져오기
     try:
         response_text = await fetch_page(url)
     except aiohttp.ClientError as e:
-        raise HTTPException(status_code=400, detail=f"Error fetching the URL: {str(e)}")
+        raise HTTPException(
+            status_code=400, detail=f"Error fetching the URL: {str(e)}"
+        ) from e
 
-    # HTML 파싱
-    soup = BeautifulSoup(response_text, 'html.parser')
-
-    # 제목 추출
-    title_element = soup.find(settings["title_tag"], class_=settings["title_class"])
-    title = title_element.get_text(strip=True) if title_element else "Title not found"
-
-    # 본문 추출
-    main_section = soup.find('div', class_=settings["content_div_class"])
-    if not main_section:
-        raise HTTPException(status_code=404, detail="Main content section not found")
-
-    paragraphs = []
-    for tag in settings["content_tags"]:
-        paragraphs.extend(main_section.find_all(tag, attrs=settings["content_attrs"]))
-
-    if not paragraphs:
-        raise HTTPException(status_code=404, detail="No content found")
+    result_html = BeautifulSoup(response_text, "html.parser")
+    title = find_title(result_html, news_type)
+    main_section = find_main_section(result_html, news_type)
+    paragraphs = [
+        para
+        for tag in news_type.value.content_tags
+        for para in main_section.find_all(tag, attrs=news_type.value.content_attrs)
+    ]
 
     content = []
-    if news_type == "MAE_KYUNG":
+    if news_type == Publisher.MAE_KYUNG:
         for para in paragraphs:
-            if para.get('refid') and para.name == 'p':
+            if para.get("refid") and para.name == "p":
                 text = para.get_text(strip=True)
                 content.append(text)
-    elif news_type == "HAN_KYUNG" or news_type == "SEOUL_KUNG":
+    elif news_type in {Publisher.HAN_KYUNG, Publisher.SEOUL_KYUNG}:
         for para in paragraphs:
-            if para.name == 'p':
+            if para.name == "p":
                 content.append(para.get_text(strip=True))
-            elif para.name == 'br':
+            elif para.name == "br":
                 text = para.previous_sibling
                 if text and isinstance(text, str):
                     content.append(text.strip())
@@ -59,6 +57,22 @@ async def extract_article(news_type: str, url: str) -> ArticleResponse:
     full_content = "\n".join(content)
 
     if not full_content.strip():
-        raise HTTPException(status_code=404, detail="No content found")
+        raise HTTPException(status_code=404, detail="파싱 결과가 없습니다.")
 
     return ArticleResponse(title=title, content=full_content)
+
+
+def find_title(soup: BeautifulSoup, news_type: Publisher) -> str:
+    title_element = soup.find(
+        news_type.value.title_tag, class_=news_type.value.title_class
+    )
+    title = title_element.get_text(strip=True) if title_element else "Title not found"
+
+    return title
+
+
+def find_main_section(result_html: BeautifulSoup, news_type: Publisher):
+    main_section = result_html.find("div", class_=news_type.value.content_div_class)
+    if not main_section:
+        raise HTTPException(status_code=404, detail="Main content section not found")
+    return main_section


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
closed: #26 
- 기존에 하드코딩 되어있었던 코드를 일부 Enum으로 수정했습니다.
- 그 외에 pylint에 몇가지 걸리는 제약사항이 있어 개선하는 작업 진행했습니다.

## 어떻게 해결했나요?
- Enum 활용했습니다.

## 고민
```python
   content = []
    if news_type == Publisher.MAE_KYUNG:
        for para in paragraphs:
            if para.get("refid") and para.name == "p":
                text = para.get_text(strip=True)
                content.append(text)
    elif news_type in {Publisher.HAN_KYUNG, Publisher.SEOUL_KYUNG}:
        for para in paragraphs:
            if para.name == "p":
                content.append(para.get_text(strip=True))
            elif para.name == "br":
                text = para.previous_sibling
                if text and isinstance(text, str):
                    content.append(text.strip())
```

이 부분도 어떻게 보면 유연하지 않다고 생각하는데 , 어떻게 개선하면 좋을지 고민이네요. 
언젠가는 다시 수정해봐야 할 것 같은데 어떻게 하면 좋을지 이야기해보면 좋을거같습니다~~

혹시 코드 실행시켜보고 싶으시면 pull받으셔서 실행시켜보면 될거같습니다~~~
근데 당장에 돌아가는데는 문제가 없어서 둘까 싶다가도 참 애매하네요🤔
@pykido 기존 코드 작성하신 태윤님께서 차후에 리팩토링 부탁드립니다!!!